### PR TITLE
Fix Makefile where rebar is not in path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REBAR=`which rebar || ./rebar`
+REBAR=`which rebar || echo ./rebar`
 PACKAGE=rh-exchange
 DIST_DIR=dist
 EBIN_DIR=ebin


### PR DESCRIPTION
If rebar is not in the path, the Makefile would run rebar and use its output instead of just using the `./rebar` path.
