### PR TITLE
Fix missing validate_binding/2 for RMQ 3.1.0

### DIFF
--- a/src/rabbit_exchange_type_recent_history.erl
+++ b/src/rabbit_exchange_type_recent_history.erl
@@ -4,7 +4,7 @@
 -behaviour(rabbit_exchange_type).
 
 -export([description/0, serialise_events/0, route/2]).
--export([validate/1, create/2, delete/3, add_binding/3,
+-export([validate/1, validate_binding/2, create/2, delete/3, add_binding/3,
          remove_bindings/3, assert_args_equivalence/2]).
 -export([setup_schema/0]).
 
@@ -36,6 +36,7 @@ route(#exchange{name = XName}, #delivery{message = #basic_message{content = Cont
     rabbit_router:match_routing_key(XName, ['_']).
 
 validate(_X) -> ok.
+validate_binding(_X, _B) -> ok.
 create(_Tx, _X) -> ok.
 
 delete(transaction, #exchange{ name = XName }, _Bs) ->

--- a/src/rabbitmq_recent_history_exchange.app.src
+++ b/src/rabbitmq_recent_history_exchange.app.src
@@ -1,6 +1,6 @@
 {application, rabbitmq_recent_history_exchange,
  [{description, "RabbitMQ Recent History Exchange"},
-  {vsn, "0.1.0"},
+  {vsn, "0.1.1"},
   {modules, []},
   {registered, []},
   {applications, [kernel, stdlib, rabbit, mnesia]}]}.


### PR DESCRIPTION
I tried to bind a "x-recent-exchange" to a Queue and it failed because `validate_binding/2` wasn't implemented.
